### PR TITLE
1 1111 ensure mounting of cramfs filesystems is disabled

### DIFF
--- a/1_Initial_Setup/1_1_Filesystem_Configuration/1_1_1_Disable_Unused_Filesystems/1_1_1_1_Ensure_Mounting_cramfs_is_disabled.sh
+++ b/1_Initial_Setup/1_1_Filesystem_Configuration/1_1_1_Disable_Unused_Filesystems/1_1_1_1_Ensure_Mounting_cramfs_is_disabled.sh
@@ -1,1 +1,57 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+####
+# Profile Applicability:
+# Level 1 - Server
+# Level 1 - Workstation
+#
+# Description:
+# The cramfs filesystem type is a compressed read-only Linux filesystem embedded in
+# small footprint systems. A cramfs image can be used without having to first decompress
+# the image.
+#
+# Rationale:
+# Removing support for unneeded filesystem types reduces the local attack surface of the
+# system. If this filesystem type is not needed, disable it.
+#
+# Additional Notes:
+# This audit must be done on the actual machine, virtualization or tools like Docker will
+# fail. This is because modprobe and lsmod may not be loaded. You can't load kernel 
+# modules in a Docker container. You need to load them on the host.
+####
+
+
+
+{
+  l_output="" l_output2=""
+  l_mname="cramfs" # set module name
+  # Check how module will be loaded
+  l_loadable="$(modprobe -n -v "$l_mname")"
+
+  if grep -Pq -- '^\h*install \/bin\/(true|false)' <<< "$l_loadable"; then
+    l_output="$l_output\n - module: \"$l_mname\" is not loadable: \"$l_loadable\""
+  else
+    l_output2="$l_output2\n - module: \"$l_mname\" is loadable: \"$l_loadable\""
+  fi
+
+  # Check is the module currently loaded
+  if ! lsmod | grep "$l_mname" > /dev/null 2>&1; then
+    l_output="$l_output\n - module: \"$l_mname\" is not loaded"
+  else
+    l_output2="$l_output2\n - module: \"$l_mname\" is loaded"
+  fi
+
+  # Check if the module is deny listed
+  if grep -Pq -- "^\h*blacklist\h+$l_mname\b" /etc/modprobe.d/*; then
+    l_output="$l_output\n - module: \"$l_mname\" is deny listed in: \"$(grep -Pl -- "^\h*blacklist\h+$l_mname\b" /etc/modprobe.d/*)\""
+  else
+    l_output2="$l_output2\n - module: \"$l_mname\" is not deny listed"
+  fi
+
+  # Report results. If no failures output in l_output2, we pass
+  if [ -z "$l_output2" ]; then
+    echo -e "\n- Audit Result:\n ** PASS **\n$l_output\n"
+  else
+    echo -e "\n- Audit Result:\n ** FAIL **\n - Reason(s) for audit failure:\n$l_output2\n" [ -n "$l_output" ] && echo -e "\n- Correctly set:\n$l_output\n"
+  fi
+}

--- a/README.md
+++ b/README.md
@@ -50,16 +50,15 @@ in this examplethe audit will test against level 2 hardness for workstations.
 
 ## Development
 
-Assuming Docker is installed. These commands will fetch the official Ubuntu 22.04 Docker image and start a container:
+Assuming Docker is installed. These commands will fetch the Sandevistan Ubuntu 22.04 Level 0 Docker image and start a container:
 
 ```
-docker pull ubuntu:22.04
-docker run -it ubuntu:22.04 /bin/bash
+docker pull shanecfast/sandevistan-ubuntu-22.04-developer-level-0:latest
+docker run -it sandevistan-ubuntu-22.04-developer-level-0:latest /bin/bash --privileged
 ```
-Once the docker image is running and you are in the terminal do the following commands to import the project:
+Levels 1 and 2 will become available as development progresses for test usage. Once the docker image is running and you are in the terminal do the following commands to import the project:
 
 ```
-apt update && apt install git -y && apt-get clean all
 git clone https://github.com/sandevistan-server-hardening/CIS_Ubuntu_22.04_LTS_Benchmark_v1.0.0.git
 chmod +x -R CIS_Ubuntu_22.04_LTS_Benchmark_v1.0.0
 cd CIS_Ubuntu_22.04_LTS_Benchmark_v1.0.0

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Assuming Docker is installed. These commands will fetch the Sandevistan Ubuntu 2
 
 ```
 docker pull shanecfast/sandevistan-ubuntu-22.04-developer-level-0:latest
-docker run -it sandevistan-ubuntu-22.04-developer-level-0:latest /bin/bash --privileged
+docker run -it sandevistan-ubuntu-22.04-developer-level-0:latest /bin/bash
 ```
 Levels 1 and 2 will become available as development progresses for test usage. Once the docker image is running and you are in the terminal do the following commands to import the project:
 

--- a/dockerFiles/developer_level_0/Dockerfile
+++ b/dockerFiles/developer_level_0/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+LABEL maintainer="shane.fast01@gmail.com" 
+RUN apt update
+RUN apt install vim -y
+RUN apt install git -y
+RUN apt-get clean all

--- a/profile/outputSetup.sh
+++ b/profile/outputSetup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+#TODO: implement output initialization to file


### PR DESCRIPTION
#### Summary 
  * *Description*: Implements audit script for 1.1.1.1 ensure mounting of cramfs filesystems is disabled
  * *Jira Ticket*: 
  * Testing Environment: sandevistan-ubuntu-22.04-developer-level-0:latest
  
#### Manual testing
  * *Context*: This audit is left detached since the docker test environment doesn't load its own kernel, which this test assumes. This should only be run against actual Ubuntu servers and not virtualized environments.
  * *How to test*: Running on a Ubuntu 22.04 server, the script should report success or failure without additional errors (such as unable to find lsmod and modprobe)
  
------------------------
    